### PR TITLE
Code/emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See: [https://www.rpnation.com]
 | Google Font Library                       | Center Block    |                  | Newspaper          |
 | HTML Comment⌨️                            | Background      |                  | Checks             |
 | Paragraph Indent                          | Border          |                  | Font Awesome Icons |
-| Bold, Italic, Underline, Strikethrough Ⓜ️ | Accordions      |                  | OOC                |
+| Bold, Italic, Underline, Strikethrough Ⓜ️✔️| Accordions      |                  | OOC                |
 | Color                                     | Scroll Box      |                  |                    |
 | Font Size                                 | Div Box         |                  |                    |
 | Left, Center, Right                       | Anchors         |                  |                    |

--- a/assets/javascripts/bbcode-parser.min.js
+++ b/assets/javascripts/bbcode-parser.min.js
@@ -24,15 +24,6 @@
         return presetFactory;
     }
 
-    const bold = (node) => {
-      // console.log(node);
-      return {
-        tag: "span",
-        attr: { style: "font-weight: bold", 'data-rpn-bbcode': '' },
-        content: node.content,
-      };
-    };
-
     // import { getUniqAttr } from "@bbob/plugin-helper";
 
     const font = (node, options) => {
@@ -65,7 +56,6 @@
     };
 
     const tags = {
-      b: bold,
       font,
       nobr,
     };

--- a/bbcode-src/preset.js
+++ b/bbcode-src/preset.js
@@ -1,10 +1,8 @@
 import { createPreset } from "@bbob/preset";
-import { bold } from "./tags/bold";
 import { font } from "./tags/font";
 import { nobr } from "./tags/nobr";
 
 const tags = {
-  b: bold,
   font,
   nobr,
 };

--- a/bbcode-src/tags/bold.js
+++ b/bbcode-src/tags/bold.js
@@ -1,8 +1,0 @@
-export const bold = (node) => {
-  // console.log(node);
-  return {
-    tag: "span",
-    attr: { style: "font-weight: bold", 'data-rpn-bbcode': '' },
-    content: node.content,
-  };
-};


### PR DESCRIPTION
Bbob already handles bold styling (as it does italics, underline, and strikethrough as well). This removes the unneeded bold code so the emphasis tags work out of the box. 