### PR TITLE
Add whitespace preservation

### DIFF
--- a/assets/javascripts/bbcode-parser.min.js
+++ b/assets/javascripts/bbcode-parser.min.js
@@ -999,7 +999,7 @@
         return nodes.toArray();
     };
 
-    /* eslint-disable no-plusplus */ const isObj$1 = (value)=>typeof value === 'object';
+    /* eslint-disable no-plusplus */ const isObj$2 = (value)=>typeof value === 'object';
     const isBool = (value)=>typeof value === 'boolean';
     function iterate(t, cb) {
         const tree = t;
@@ -1007,7 +1007,7 @@
             for(let idx = 0; idx < tree.length; idx++){
                 tree[idx] = iterate(cb(tree[idx]), cb);
             }
-        } else if (tree && isObj$1(tree) && tree.content) {
+        } else if (tree && isObj$2(tree) && tree.content) {
             iterate(tree.content, cb);
         }
         return tree;
@@ -1016,7 +1016,7 @@
         if (typeof expected !== typeof actual) {
             return false;
         }
-        if (!isObj$1(expected) || expected === null) {
+        if (!isObj$2(expected) || expected === null) {
             return expected === actual;
         }
         if (Array.isArray(expected)) {
@@ -1025,7 +1025,7 @@
         return Object.keys(expected).every((key)=>{
             const ao = actual[key];
             const eo = expected[key];
-            if (isObj$1(eo) && eo !== null && ao !== null) {
+            if (isObj$2(eo) && eo !== null && ao !== null) {
                 return same(eo, ao);
             }
             if (isBool(eo)) {
@@ -1045,7 +1045,7 @@
         }) : iterate(this, (node)=>same(expression, node) ? cb(node) : node);
     }
 
-    function walk$1(cb) {
+    function walk$2(cb) {
         return iterate(this, cb);
     }
     function bbob(plugs) {
@@ -1069,7 +1069,7 @@
                 const raw = tree;
                 tree.messages = [];
                 tree.options = options;
-                tree.walk = walk$1;
+                tree.walk = walk$2;
                 tree.match = match;
                 plugins.forEach((plugin)=>{
                     tree = plugin(tree, {
@@ -1144,6 +1144,78 @@
                 stripTags
             }), '');
     const render = renderNodes;
+
+    /**
+     * Plugin that converts consecutive normal spaces (U+0020) to non-breaking spaces (U+00A0).
+     * To use, put as function similar to the presets.
+     *
+     *
+     * @example
+     * ```ts
+     * const output = bbob([preset(), , preserveWhitespace(), lineBreakPlugin()]).process(input, {render}).html
+     * ```
+     */
+
+    /**
+     * Checks if input is an object
+     * @param value input
+     * @returns if value is an object
+     */
+    const isObj$1 = (value) => typeof value === "object";
+
+    /**
+     * Walks the tree of nodes. Checks for node of consecutive spaces. If found replaces every space in
+     * node with a nonbreaking space.
+     * Preserves multiple spaces so html won't truncate them.
+     *
+     * Walks through entire tree.
+     * @param t tree of nodes to be processed
+     * @returns modified tree
+     */
+    const walk$1 = (t) => {
+      const tree = t;
+
+      if (Array.isArray(tree)) {
+        for (let idx = 0; idx < tree.length; idx++) {
+          const child = walk$1(tree[idx]);
+          if (Array.isArray(child)) {
+            tree.splice(idx, 1, ...child);
+            idx += child.length - 1;
+          } else {
+            tree[idx] = child;
+          }
+        }
+      } else if (tree && isObj$1(tree) && tree.content) {
+
+        walk$1(tree.content);
+      }
+
+      //Bbob breaks up nodes by the presence of normal spaces.
+      //So a node with a normal space can only have normal spaces in that node.
+      if (isStringNode(tree)) {
+        if(tree.length > 1 && tree[0] === " ") {
+          let numSpaces = tree.length;
+          return [String.fromCharCode(160).repeat(numSpaces)];
+        }
+      }
+
+      return tree;
+    };
+
+    /**
+     * Converts consecutive normal spaces (U+0020) to nonbreaking spaces (U+00A0).
+     * Supply this as a plugin in the preset lists.
+     *
+     * @example converts consecutive normal spaces (U+0020) to nonbreaking spaces (U+00A0)
+     * ```ts
+     * const output = bbob([preset(), preserveWhitespace(), lineBreakPlugin()]).process(input, {render}).html
+     * ```
+     *
+     * @returns plugin to be used in BBob process
+     */
+    const preserveWhitespace = () => {
+      return (tree) => walk$1(tree);
+    };
 
     /**
      * Plugin that converts line breaks to `<br/>` tags.
@@ -1232,7 +1304,7 @@
     };
 
     const RpNBBCode = (code) =>
-      bbob([preset(), lineBreakPlugin()]).process(code, {
+      bbob([preset(), preserveWhitespace(), lineBreakPlugin()]).process(code, {
         render,
         ...options,
       });

--- a/assets/javascripts/bbcode-parser.min.js
+++ b/assets/javascripts/bbcode-parser.min.js
@@ -1303,11 +1303,17 @@
       data,
     };
 
-    const RpNBBCode = (code) =>
-      bbob([preset(), preserveWhitespace(), lineBreakPlugin()]).process(code, {
+    const RpNBBCode = (code, opts) => {
+      const plugins = [preset()];
+      if (opts.preserveWhitespace){
+        plugins.push(preserveWhitespace());
+      }
+      plugins.push(lineBreakPlugin());
+      return bbob(plugins).process(code,{
         render,
         ...options,
-      });
+        });
+    };
 
     exports.RpNBBCode = RpNBBCode;
 

--- a/assets/javascripts/lib/discourse-markdown/bbcode-plugin.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode-plugin.js
@@ -3,7 +3,7 @@
  * @param {string} raw content to preprocess into HTML
  * @returns processed HTML string to pass into markdown-it
  */
-function preprocessor(raw) {
+function preprocessor(raw,opts) {
   // eslint-disable-next-line no-undef
   if (!bbcodeParser) {
     // parser doesn't exist. Something horrible has happened and somehow the parser wasn't imported/initialized
@@ -18,7 +18,7 @@ function preprocessor(raw) {
   }
   const parser = globalThis.bbcodeParser.RpNBBCode;
 
-  const processed = parser(raw);
+  const processed = parser(raw, opts);
   return processed.html;
 }
 
@@ -33,13 +33,18 @@ export function setup(helper) {
       return;
     }
 
+    //Add check site settings for options to send to RpNBBCode
+    let preprocessor_options = {
+      preserveWhitespace: (siteSettings.preserve_whitespace && !siteSettings.discourse_normalize_whitespace)
+    };
+
     Object.defineProperty(opts, "engine", {
       configurable: true,
       set(engine) {
         const md = engine.render;
         engine.set({ breaks: false }); // disable breaks. Let BBob handle line breaks.
         engine.render = function (raw) {
-          const preprocessed = preprocessor(raw);
+          const preprocessed = preprocessor(raw, preprocessor_options);
           const processed = md.apply(this, [preprocessed]);
           return processed;
         };

--- a/bbcode-src/index.js
+++ b/bbcode-src/index.js
@@ -16,8 +16,14 @@ const options = {
   data,
 };
 
-export const RpNBBCode = (code) =>
-  bbob([preset(), preserveWhitespace(), lineBreakPlugin()]).process(code, {
+export const RpNBBCode = (code, opts) => {
+  const plugins = [preset()];
+  if (opts.preserveWhitespace){
+    plugins.push(preserveWhitespace());
+  }
+  plugins.push(lineBreakPlugin());
+  return bbob(plugins).process(code,{
     render,
     ...options,
-  });
+    });
+};

--- a/bbcode-src/index.js
+++ b/bbcode-src/index.js
@@ -1,6 +1,7 @@
 import { availableTags, preset } from "./preset";
 import bbob from "@bbob/core";
 import { render } from "@bbob/html";
+import { preserveWhitespace } from "./plugins/preserveWhitespace";
 import { lineBreakPlugin } from "./plugins/lineBreak";
 
 const data = [];
@@ -16,7 +17,7 @@ const options = {
 };
 
 export const RpNBBCode = (code) =>
-  bbob([preset(), lineBreakPlugin()]).process(code, {
+  bbob([preset(), preserveWhitespace(), lineBreakPlugin()]).process(code, {
     render,
     ...options,
   });

--- a/bbcode-src/plugins/preserveWhitespace.js
+++ b/bbcode-src/plugins/preserveWhitespace.js
@@ -1,0 +1,72 @@
+/**
+ * Plugin that converts consecutive normal spaces (U+0020) to non-breaking spaces (U+00A0).
+ * To use, put as function similar to the presets.
+ *
+ *
+ * @example
+ * ```ts
+ * const output = bbob([preset(), , preserveWhitespace(), lineBreakPlugin()]).process(input, {render}).html
+ * ```
+ */
+import { isStringNode } from "@bbob/plugin-helper";
+
+/**
+ * Checks if input is an object
+ * @param value input
+ * @returns if value is an object
+ */
+const isObj = (value) => typeof value === "object";
+
+/**
+ * Walks the tree of nodes. Checks for node of consecutive spaces. If found replaces every space in
+ * node with a nonbreaking space.
+ * Preserves multiple spaces so html won't truncate them.
+ *
+ * Walks through entire tree.
+ * @param t tree of nodes to be processed
+ * @returns modified tree
+ */
+const walk = (t) => {
+  const tree = t;
+
+  if (Array.isArray(tree)) {
+    for (let idx = 0; idx < tree.length; idx++) {
+      const child = walk(tree[idx]);
+      if (Array.isArray(child)) {
+        tree.splice(idx, 1, ...child);
+        idx += child.length - 1;
+      } else {
+        tree[idx] = child;
+      }
+    }
+  } else if (tree && isObj(tree) && tree.content) {
+
+    walk(tree.content);
+  }
+
+  //Bbob breaks up nodes by the presence of normal spaces.
+  //So a node with a normal space can only have normal spaces in that node.
+  if (isStringNode(tree)) {
+    if(tree.length > 1 && tree[0] === " ") {
+      let numSpaces = tree.length;
+      return [String.fromCharCode(160).repeat(numSpaces)];
+    }
+  }
+
+  return tree;
+};
+
+/**
+ * Converts consecutive normal spaces (U+0020) to nonbreaking spaces (U+00A0).
+ * Supply this as a plugin in the preset lists.
+ *
+ * @example converts consecutive normal spaces (U+0020) to nonbreaking spaces (U+00A0)
+ * ```ts
+ * const output = bbob([preset(), preserveWhitespace(), lineBreakPlugin()]).process(input, {render}).html
+ * ```
+ *
+ * @returns plugin to be used in BBob process
+ */
+export const preserveWhitespace = () => {
+  return (tree) => walk(tree);
+};

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,5 @@ en:
   site_settings:
     bbcode_enabled: "Enable Custom BBCode parser"
     discourse_normalize_whitespace: "Activate to set all whitespace to the default space character (U+0020)"
+    preserve_whitespace: "Activate to set repeating spaces (U+0020) to non-breaking spaces (U+00A0).
+      Note that discourse_normalize_whitespace must be disabled to preserve non-breaking spaces."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,4 @@
 en:
   site_settings:
     bbcode_enabled: "Enable Custom BBCode parser"
+    discourse_normalize_whitespace: "Activate to set all whitespace to the default space character (U+0020)"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,9 @@ plugins:
     client: true
     description:
       en: "Activate to set all whitespace to the default space character (U+0020)"
+  preserve_whitespace:
+    default: true
+    client: true
+    description:
+      en: "Activate to set repeating spaces (U+0020) to non-breaking spaces (U+00A0).
+      Note that discourse_normalize_whitespace must be disabled to preserve non-breaking spaces."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,8 @@ plugins:
   markdown_typographer_quotation_marks:
     client: false
     default: false
+  discourse_normalize_whitespace:
+    default: false
+    client: true
+    description:
+      en: "Activate to set all whitespace to the default space character (U+0020)"

--- a/plugin.rb
+++ b/plugin.rb
@@ -28,4 +28,26 @@ after_initialize do
   # Code which should run after Rails has finished booting
   # should clear out the context so the initial setup logic for bbcode parser runs
   PrettyText.reset_context()
+
+  # overrides the default normalize_whitespaces function in discourse/lib/text_cleaner.rb
+  # adds discourse_normalize_whitespace setting (defaults to false)
+  # when true, normalize_whitespace runs as normal
+  # when false, it does nothing, which allows for persistence of non-default whitespace.
+  class ::TextCleaner
+    module Optional_normalize_whitespace
+      def title_options
+        options = super
+        options[:normalize_whitespace_opt] = SiteSetting.discourse_normalize_whitespace
+        options
+      end
+      def normalize_whitespaces(text)
+        options = title_options
+        if(options[:normalize_whitespace_opt])
+          text = super(text)
+        end
+        text
+      end
+    end
+    singleton_class.prepend Optional_normalize_whitespace
+  end
 end


### PR DESCRIPTION
I've added a toggleable override to the TextCleaner discourse class in plugin.rb to prevent discourse from converting non-standard whitespace to a default space. 

The settings.yml and server site settings have been updated to allow this feature to be turned back on (it is set to off by default).

There is a perserveWhitespace.js plugin that walks the tree similar to the linebreak plugin, but it only looks for nodes with multiple normal spaces and replaces them with nonbreaking spaces. 

The bbcode-parser.min is also updated with these changes. 

I've tested this in my local discourse instance and it seems to function properly. You can put as many spaces as you want in the composer and it will show up in preview and persist into the post. 