### PR TITLE
Tech/tag refactor

### DIFF
--- a/assets/javascripts/bbcode-parser.min.js
+++ b/assets/javascripts/bbcode-parser.min.js
@@ -197,7 +197,7 @@
     * @file Adds [left], [center], and [right] to bbcode
     * @example [center]content[/center]
     */
-    const alignmenttags = {
+    const alignment = {
         left: (node) => toNode('div', { class: 'bb-left' }, node.content),
         center: (node) => toNode('div', { class: 'bb-center' }, node.content),
         right: (node) => toNode('div', { class: 'bb-right' }, node.content)
@@ -395,9 +395,9 @@
     };
 
     const tags = {
+      ...alignment,
       font,
       nobr,
-      ...alignmenttags,
       highlight,
       spoiler,
       inlinespoiler,

--- a/assets/javascripts/bbcode-parser.min.js
+++ b/assets/javascripts/bbcode-parser.min.js
@@ -396,21 +396,21 @@
 
     const tags = {
       ...alignment,
-      font,
-      nobr,
-      highlight,
-      spoiler,
-      inlinespoiler,
-      color,
-      size,
       bg,
       border,
-      divide,
-      ooc,
-      side,
-      justify,
-      pindent,
       check,
+      color,
+      divide,
+      font,
+      highlight,
+      inlinespoiler,
+      justify,
+      nobr,
+      ooc,
+      pindent,
+      side,
+      size,
+      spoiler,
     };
 
     const availableTags = Object.keys(tags);

--- a/assets/javascripts/bbcode-parser.min.js
+++ b/assets/javascripts/bbcode-parser.min.js
@@ -189,8 +189,8 @@
     * @file Adds [highlight] to bbcode
     * @example [highlight]content[/highlight]
     */
-    const highlight = {
-        highlight: (node) => toNode('span', { class: 'bb-highlight' }, node.content),
+    const highlight = (node) => {
+        return toNode('span', { class: 'bb-highlight' }, node.content);
     };
 
     /**
@@ -389,20 +389,16 @@
       return toNode("div", { class: "bb-justify" }, node.content);
     };
 
-    /**
-     * @file Adds [check] to bbcode
-     * @example [check]content[/check]
-     */
     const check = (node) => {
         const attrs = preprocessAttr(node.attrs)._default || "dot";
-        return toNode( "div", { class: `bb-check`, "data-type": attrs }, node.content);
+        return toNode("div",  { class: `bb-check`, "data-type": attrs },  node.content );
     };
 
     const tags = {
       font,
       nobr,
       ...alignmenttags,
-      ...highlight,
+      highlight,
       spoiler,
       inlinespoiler,
       color,

--- a/assets/javascripts/lib/discourse-markdown/bbcode-plugin.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode-plugin.js
@@ -74,7 +74,6 @@ export function setup(helper) {
     "div.bb-center",
     "div.bb-left",
     "div.bb-right",
-    "div.bb-*",
     "div[style=*]",
     "span.bb-highlight",
     "span[style=*]",

--- a/assets/javascripts/lib/discourse-markdown/bbcode-plugin.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode-plugin.js
@@ -71,36 +71,23 @@ export function setup(helper) {
   });
 
   helper.allowList([
-    "div.bb-center",
-    "div.bb-left",
-    "div.bb-right",
-    "div[style=*]",
-    "span.bb-highlight",
-    "span[style=*]",
-    "details.bb-spoiler",
-    "summary",
-    "div.bb-spoiler-content",
-    "span.bb-inline-spoiler",
     "div.bb-background",
     "div.bb-border",
-    "span.bb-divide",
-    "div.bb-ooc",
-    "div.bb-side",
-    "span.bb-pindent",
-    "div.bb-justify",
+    "div.bb-center",
     "div.bb-check",
+    "div.bb-justify",
+    "div.bb-left",
+    "div.bb-ooc",
+    "div.bb-right",
+    "div.bb-side",
+    "div.bb-spoiler-content",
+    "div[style=*]",
+    "details.bb-spoiler",
+    "span.bb-divide",
+    "span.bb-inline-spoiler",
+    "span.bb-highlight",
+    "span.bb-pindent",
+    "span[style=*]",
+    "summary",
   ]);
-
-  /**
-   * Allow lister for google fonts
-   */
-  // helper.allowList({
-  //   custom(tag, name, value) {
-  //     console.error(tag, name, value);
-  //     if (tag === "link" && name === "href") {
-  //       return false;
-  //     }
-  //     return false;
-  //   },
-  // });
 }

--- a/bbcode-src/preset.js
+++ b/bbcode-src/preset.js
@@ -17,21 +17,21 @@ import { check } from "./tags/check";
 
 const tags = {
   ...alignment,
-  font,
-  nobr,
-  highlight,
-  spoiler,
-  inlinespoiler,
-  color,
-  size,
   bg,
   border,
-  divide,
-  ooc,
-  side,
-  justify,
-  pindent,
   check,
+  color,
+  divide,
+  font,
+  highlight,
+  inlinespoiler,
+  justify,
+  nobr,
+  ooc,
+  pindent,
+  side,
+  size,
+  spoiler,
 };
 
 const availableTags = Object.keys(tags);

--- a/bbcode-src/preset.js
+++ b/bbcode-src/preset.js
@@ -2,7 +2,7 @@ import { createPreset } from "@bbob/preset";
 import { font } from "./tags/font";
 import { nobr } from "./tags/nobr";
 import { highlight } from "./tags/highlight";
-import { alignmenttags } from "./tags/alignment";
+import { alignment } from "./tags/alignment";
 import { inlinespoiler, spoiler } from "./tags/spoiler";
 import { color } from "./tags/color";
 import { size } from "./tags/size";
@@ -16,9 +16,9 @@ import { justify } from "./tags/justify";
 import { check } from "./tags/check";
 
 const tags = {
+  ...alignment,
   font,
   nobr,
-  ...alignmenttags,
   highlight,
   spoiler,
   inlinespoiler,

--- a/bbcode-src/preset.js
+++ b/bbcode-src/preset.js
@@ -19,7 +19,7 @@ const tags = {
   font,
   nobr,
   ...alignmenttags,
-  ...highlight,
+  highlight,
   spoiler,
   inlinespoiler,
   color,

--- a/bbcode-src/tags/alignment.js
+++ b/bbcode-src/tags/alignment.js
@@ -3,7 +3,7 @@ import { toNode } from "../utils/common";
 * @file Adds [left], [center], and [right] to bbcode
 * @example [center]content[/center]
 */
-export const alignmenttags = {
+export const alignment = {
     left: (node) => toNode('div', { class: 'bb-left' }, node.content),
     center: (node) => toNode('div', { class: 'bb-center' }, node.content),
     right: (node) => toNode('div', { class: 'bb-right' }, node.content)

--- a/bbcode-src/tags/highlight.js
+++ b/bbcode-src/tags/highlight.js
@@ -3,6 +3,6 @@ import { toNode } from "../utils/common";
 * @file Adds [highlight] to bbcode
 * @example [highlight]content[/highlight]
 */
-export const highlight = {
-    highlight: (node) => toNode('span', { class: 'bb-highlight' }, node.content),
+export const highlight = (node) => {
+    return toNode('span', { class: 'bb-highlight' }, node.content);
 };


### PR DESCRIPTION
This pull request refactors a handful of small items so they match convention a little better. 

1. Refactors highlight to follow the node generation convention we follow for single-tag files. #58 
2. Renames the alignment tag export so it matches the rest of the tags
3. Removes the div.bb-* wildcard from the allowlist since it wasn't doing anything. 
4. Alphebetizes both the tag and allow lists. 