### PR TITLE
Added to lowercase during context free check

### DIFF
--- a/assets/bundled/bbcode-parser.min.js
+++ b/assets/bundled/bbcode-parser.min.js
@@ -1052,7 +1052,7 @@
     };
 
     const availableTags = Object.keys(tags);
-    const preventParsing = ["plain", "code", "CODE", "icode"];
+    const preventParsing = ["plain", "code", "icode"];
 
     const preset = createPreset(tags);
 
@@ -1528,7 +1528,6 @@
             if (contextFreeTag !== '' && isClosingTag) {
                 contextFreeTag = '';
             }
-
             if (contextFreeTag === '' && contextFreeTags.includes(name.toLowerCase())) {
                 contextFreeTag = name;
             }

--- a/assets/bundled/bbcode-parser.min.js
+++ b/assets/bundled/bbcode-parser.min.js
@@ -261,7 +261,7 @@
       const attrs = preprocessAttr(node.attrs)._default || "dot";
       return toNode("div", { class: `bb-check`, "data-type": attrs }, node.content);
     };
-
+ 
     /**
      * processes [code] tag and returns a fenced code block
      */
@@ -1052,7 +1052,7 @@
     };
 
     const availableTags = Object.keys(tags);
-    const preventParsing = ["plain", "code", "icode"];
+    const preventParsing = ["plain", "code", "CODE", "icode"];
 
     const preset = createPreset(tags);
 
@@ -1528,7 +1528,8 @@
             if (contextFreeTag !== '' && isClosingTag) {
                 contextFreeTag = '';
             }
-            if (contextFreeTag === '' && contextFreeTags.includes(name)) {
+
+            if (contextFreeTag === '' && contextFreeTags.includes(name.toLowerCase())) {
                 contextFreeTag = name;
             }
         };


### PR DESCRIPTION

### Issue
- #98 

### Requirements Met
- `[code]` and `[CODE]` are acting differently than expected no matter the bbcode involved. Resolve this.

### Notes
- A string array contained the lowercase version of code. Adding "CODE" switched all code blocks that showed html markups to show bbcode markup. The `name` variable should never be undefined from what I can tell so I tacked on a `toLowerCase()`  in order to prevent us having to add to the string array.