### PR TITLE
Fixes issue where markdown tables are broken due to line break

### DIFF
--- a/assets/bundled/bbcode-parser.min.js
+++ b/assets/bundled/bbcode-parser.min.js
@@ -88,6 +88,7 @@
     const URL_REGEX_SINGLE_LINE = new RegExp(`^${URL_REGEX.source}|${MD_URL_REGEX.source}$`);
     const ESCAPABLES_REGEX =
       /((\n|^)(?<fence>```+|~~~+)(?<fenceInfo>.*\n))|(?<bbcode>\[(?<bbcodeTag>i?code|plain)(=.*)?\])|(?<backtick>(?<tickStart>`{1,2})(.*)(?<tickEnd>\k<tickStart>))/im;
+    const MD_TABLE_REGEX = /^(\|[^\n]+\|\r?\n)((?:\|:?[-]+:?)+\|)(\n(?:\|[^\n]+\|\r?\n?)*)?$/m;
 
     /**
      * Generates a random GUID.
@@ -2732,13 +2733,30 @@
     }
 
     /**
+     * Find all markdown table blocks and mark them to ignore newlines
+     * @param {string} raw input to preprocess
+     * @returns processed string
+     */
+    function mdTableBlockPreprocess(content, data) {
+      let index = 0;
+      while ((index = regexIndexOf(content, MD_TABLE_REGEX, index)) !== -1) {
+        const match = MD_TABLE_REGEX.exec(content.substring(index));
+        const table = match[0];
+        const replacement = `[saveNL]\n${table}\n[/saveNL]`;
+        content = content.substring(0, index) + replacement + content.substring(index + table.length);
+        index = index + replacement.length;
+      }
+      return [content, data];
+    }
+
+    /**
      * Preprocesses input to be formatted for bbob to intake. Handles any necessary functionality that BBob can't handle with a plugin (i.e. hoisting).
      * @param {string} raw input to preprocess
      * @returns formatted input for bbob to intake
      */
     function preprocessRaw(raw) {
       let data = {};
-      const preprocessors = [fenceCodeBlockPreprocess];
+      const preprocessors = [fenceCodeBlockPreprocess, mdTableBlockPreprocess];
       for (const preprocessor of preprocessors) {
         [raw, data] = preprocessor(raw, data);
       }

--- a/bbcode-src/utils/common.js
+++ b/bbcode-src/utils/common.js
@@ -62,6 +62,7 @@ const MD_URL_REGEX =
 const URL_REGEX_SINGLE_LINE = new RegExp(`^${URL_REGEX.source}|${MD_URL_REGEX.source}$`);
 const ESCAPABLES_REGEX =
   /((\n|^)(?<fence>```+|~~~+)(?<fenceInfo>.*\n))|(?<bbcode>\[(?<bbcodeTag>i?code|plain)(=.*)?\])|(?<backtick>(?<tickStart>`{1,2})(.*)(?<tickEnd>\k<tickStart>))/im;
+const MD_TABLE_REGEX = /^(\|[^\n]+\|\r?\n)((?:\|:?[-]+:?)+\|)(\n(?:\|[^\n]+\|\r?\n?)*)?$/m;
 
 /**
  * Generates a random GUID.
@@ -94,6 +95,7 @@ export {
   MD_NEWLINE_PRE_INJECT,
   URL_REGEX,
   MD_URL_REGEX,
+  MD_TABLE_REGEX,
   URL_REGEX_SINGLE_LINE,
   ESCAPABLES_REGEX,
 };


### PR DESCRIPTION
Fixes an issue noted in #36 where markdown tables are breaking due to the line break process messing with them.

wraps markdown tables in markers to preserve the newlines

<img width="962" alt="image" src="https://github.com/RpNation/bbcode/assets/42795314/260866a6-4a60-4032-b800-5c655bb7604f">
