### PR TITLE
Update decorateCookedElement to run only on main document

### DIFF
--- a/assets/javascripts/discourse/initializers/accordion.js
+++ b/assets/javascripts/discourse/initializers/accordion.js
@@ -99,7 +99,7 @@ class Accordion {
       {
         duration: 400,
         easing: "linear",
-      },
+      }
     );
 
     // When the animation is complete, call onAnimationFinish()
@@ -149,7 +149,7 @@ class Accordion {
       {
         duration: 400,
         easing: "linear",
-      },
+      }
     );
     // When the animation is complete, call onAnimationFinish()
     slide.animation.onfinish = () => this.onAnimationFinish(true, slide);
@@ -180,7 +180,7 @@ class Accordion {
  * @param api
  */
 function initializeAccordion(api) {
-  api.decorateCookedElement(addAccordionCode, { id: "add accordions" });
+  api.decorateCookedElement(addAccordionCode, { id: "add accordions", afterAdopt: true });
 }
 
 export default {

--- a/assets/javascripts/discourse/initializers/accordion.js
+++ b/assets/javascripts/discourse/initializers/accordion.js
@@ -99,7 +99,7 @@ class Accordion {
       {
         duration: 400,
         easing: "linear",
-      }
+      },
     );
 
     // When the animation is complete, call onAnimationFinish()
@@ -149,7 +149,7 @@ class Accordion {
       {
         duration: 400,
         easing: "linear",
-      }
+      },
     );
     // When the animation is complete, call onAnimationFinish()
     slide.animation.onfinish = () => this.onAnimationFinish(true, slide);

--- a/assets/javascripts/discourse/initializers/google-font.js
+++ b/assets/javascripts/discourse/initializers/google-font.js
@@ -50,6 +50,7 @@ function linkBuilder(data) {
 function initializeFont(api) {
   api.decorateCookedElement((elem) => addGoogleFont(elem), {
     id: "add google font",
+    afterAdopt: true,
   });
 }
 

--- a/assets/javascripts/discourse/initializers/inlinespoiler.js
+++ b/assets/javascripts/discourse/initializers/inlinespoiler.js
@@ -30,6 +30,7 @@ function toggleInlineSpoiler(event) {
 function initializeSpoiler(api) {
   api.decorateCookedElement(addInlineSpoilerCode, {
     id: "add inline spoilers",
+    afterAdopt: true,
   });
 }
 

--- a/assets/javascripts/discourse/initializers/spoiler.js
+++ b/assets/javascripts/discourse/initializers/spoiler.js
@@ -71,7 +71,7 @@ class Spoiler {
       {
         duration: 200,
         easing: "ease-in-out",
-      },
+      }
     );
 
     // When the animation is complete, call onAnimationFinish()
@@ -112,7 +112,7 @@ class Spoiler {
       {
         duration: 200,
         easing: "ease-in-out",
-      },
+      }
     );
     // When the animation is complete, call onAnimationFinish()
     this.animation.onfinish = () => this.onAnimationFinish(true);
@@ -139,7 +139,7 @@ class Spoiler {
  * @param api
  */
 function initializeSpoiler(api) {
-  api.decorateCookedElement(addSpoilerCode, { id: "add spoilers" });
+  api.decorateCookedElement(addSpoilerCode, { id: "add spoilers", afterAdopt: true });
 }
 
 export default {

--- a/assets/javascripts/discourse/initializers/spoiler.js
+++ b/assets/javascripts/discourse/initializers/spoiler.js
@@ -71,7 +71,7 @@ class Spoiler {
       {
         duration: 200,
         easing: "ease-in-out",
-      }
+      },
     );
 
     // When the animation is complete, call onAnimationFinish()
@@ -112,7 +112,7 @@ class Spoiler {
       {
         duration: 200,
         easing: "ease-in-out",
-      }
+      },
     );
     // When the animation is complete, call onAnimationFinish()
     this.animation.onfinish = () => this.onAnimationFinish(true);


### PR DESCRIPTION
Needs testing, but should improve loading posts with accordions, tabs, spoilers, and google font by only performing dom manipulations in the real dom instead of the ember virtual dom